### PR TITLE
RTL Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can set the following properties.
 | `enableSSR`           | `PropTypes.bool`                                            | `false`                          | Render component on the server side. [More info](https://github.com/ctrlplusb/react-sizeme#server-side-rendering).                      |
 | `onLayout`            | `PropTypes.func`                                            | `null`                           | It is called at the timing when the layout is confirmed, or at the updated timing. (Called only by client.)                             |
 | `horizontal`          | `PropTypes.bool`                                            | `false`                          | The transposed (horizontal) order of drawing elements. Retains the original order of the items.                                         |
-
+| `rtl`                 | `PropTypes.bool`                                            | `false`                          | When true, items are placed right-to-left instead of the default left-to-right.  Useful for RTL languages such as Arabic and Hebrew.    |
 
 
 ## Instance API

--- a/docs/js/components/DemoControl.js
+++ b/docs/js/components/DemoControl.js
@@ -52,6 +52,10 @@ export default class DemoControl extends Component {
     this.props.onTransitionChange(e.target.value);
   }
 
+  handleRTLChange = (e) => {
+    this.props.onRTLChange(e.target.checked);
+  }
+
   render() {
     const {
       duration,
@@ -59,6 +63,7 @@ export default class DemoControl extends Component {
       gutter,
       easing,
       transition,
+      rtl,
     } = this.props;
 
     return (
@@ -132,6 +137,12 @@ export default class DemoControl extends Component {
             )}
           </select>
         </div>
+
+        <div>
+          <label>RTL</label>
+          <input type="checkbox" checked={rtl} onClick={this.handleRTLChange} />
+        </div>
+
       </div>
     );
   }

--- a/docs/js/pages/Home.js
+++ b/docs/js/pages/Home.js
@@ -34,6 +34,7 @@ export default class Home extends Component {
       gutter: 5,
       easing: easings.quartOut,
       transition: 'fadeDown',
+      rtl: false,
     };
   }
 
@@ -109,6 +110,10 @@ export default class Home extends Component {
     this.setState({ transition });
   }
 
+  handleRTLChange = (rtl) => {
+    this.setState({ rtl });
+  }
+
   render() {
     const {
       items,
@@ -117,10 +122,10 @@ export default class Home extends Component {
       gutter,
       easing,
       transition: transitionSelect,
+      rtl,
     } = this.state;
 
     const transition = transitions[transitionSelect];
-
     return (
       <div>
         <DemoControl
@@ -129,6 +134,7 @@ export default class Home extends Component {
           gutter={gutter}
           easing={easing}
           transition={transition}
+          rtl={rtl}
           onShuffle={this.shuffleItems}
           onPrepend={this.prependItem}
           onAppend={this.appendItem}
@@ -138,6 +144,7 @@ export default class Home extends Component {
           onGutterChange={this.handleGutterChange}
           onEasingChange={this.handleEasingChange}
           onTransitionChange={this.handleTransitionChange}
+          onRTLChange={this.handleRTLChange}
         />
 
         <StackGrid
@@ -151,6 +158,7 @@ export default class Home extends Component {
           enter={transition.enter}
           entered={transition.entered}
           leaved={transition.leaved}
+          rtl={rtl}
           onLayout={() => {
             console.log('[DEMO] `onLayout()` has been called.'); // eslint-disable-line
           }}

--- a/src/components/GridItem.js
+++ b/src/components/GridItem.js
@@ -29,6 +29,7 @@ type Props = {
   userAgent: ?string;
   onMounted: Function;
   onUnmount: Function;
+  rtl: boolean;
 };
 
 type State = Object;
@@ -39,8 +40,8 @@ const getTransitionStyles = (type: string, props: Props): Object => {
   return props[type](rect, containerSize, index);
 };
 
-const getPositionStyles = (rect: Rect, zIndex: number): Object => ({
-  translateX: `${rect.left}px`,
+const getPositionStyles = (rect: Rect, zIndex: number, rtl: boolean): Object => ({
+  translateX: `${rtl ? -rect.left : rect.left}px`,
   translateY: `${rect.top}px`,
   zIndex,
 });
@@ -83,6 +84,7 @@ export default class GridItem extends Component {
     userAgent: PropTypes.string,
     onMounted: PropTypes.func,
     onUnmount: PropTypes.func,
+    rtl: PropTypes.bool,
   };
 
   constructor(props: Props) {
@@ -93,7 +95,7 @@ export default class GridItem extends Component {
     this.node = null;
 
     this.state = {
-      ...getPositionStyles(props.rect, 1),
+      ...getPositionStyles(props.rect, 1, props.rtl),
       ...getTransitionStyles('appear', props),
     };
   }
@@ -115,7 +117,7 @@ export default class GridItem extends Component {
       raf(() => {
         this.setStateIfNeeded({
           ...this.state,
-          ...getPositionStyles(nextProps.rect, 2),
+          ...getPositionStyles(nextProps.rect, 2, nextProps.rtl),
         });
       });
     }
@@ -160,14 +162,14 @@ export default class GridItem extends Component {
     this.setStateIfNeeded({
       ...this.state,
       ...getTransitionStyles('appeared', this.props),
-      ...getPositionStyles(this.props.rect, 1),
+      ...getPositionStyles(this.props.rect, 1, this.props.rtl),
     });
   }
 
   setEnterStyles() {
     this.setStateIfNeeded({
       ...this.state,
-      ...getPositionStyles(this.props.rect, 2),
+      ...getPositionStyles(this.props.rect, 2, this.props.rtl),
       ...getTransitionStyles('enter', this.props),
     });
   }
@@ -176,14 +178,14 @@ export default class GridItem extends Component {
     this.setStateIfNeeded({
       ...this.state,
       ...getTransitionStyles('entered', this.props),
-      ...getPositionStyles(this.props.rect, 1),
+      ...getPositionStyles(this.props.rect, 1, this.props.rtl),
     });
   }
 
   setLeaveStyles() {
     this.setStateIfNeeded({
       ...this.state,
-      ...getPositionStyles(this.props.rect, 2),
+      ...getPositionStyles(this.props.rect, 2, this.props.rtl),
       ...getTransitionStyles('leaved', this.props),
     });
   }
@@ -209,6 +211,7 @@ export default class GridItem extends Component {
       units,
       vendorPrefix,
       userAgent,
+      rtl,
       ...rest
     } = this.props;
 
@@ -217,7 +220,7 @@ export default class GridItem extends Component {
       display: 'block',
       position: 'absolute',
       top: 0,
-      left: 0,
+      ...(rtl ? { right: 0 } : { left: 0 }),
       width: rect.width,
       transition: transition(['opacity', 'transform'], duration, easing),
     }, units, vendorPrefix, userAgent);

--- a/src/components/StackGrid.js
+++ b/src/components/StackGrid.js
@@ -81,6 +81,7 @@ type Props = {
   enableSSR: boolean;
   onLayout: Function;
   horizontal: boolean;
+  rtl: boolean;
 };
 
 type InlineState = {
@@ -134,6 +135,7 @@ const propTypes = {
   enableSSR: PropTypes.bool,
   onLayout: PropTypes.func,
   horizontal: PropTypes.bool,
+  rtl: PropTypes.bool,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -341,6 +343,7 @@ export class GridInline extends Component {
       enableSSR,
       onLayout,
       horizontal,
+      rtl,
       refCallback,
       /* eslint-enable no-unused-vars */
       className,
@@ -382,6 +385,7 @@ export class GridInline extends Component {
             key={child.key}
             itemKey={child.key}
             rect={rects[i]}
+            rtl={rtl}
             containerSize={containerSize}
             onMounted={this.handleItemMounted}
             onUnmount={this.handleItemUnmount}
@@ -426,6 +430,7 @@ export default class StackGrid extends Component {
     enableSSR: false,
     onLayout: null,
     horizontal: false,
+    rtl: false,
   };
 
   props: Props;

--- a/src/components/__tests__/StackGrid.spec.js
+++ b/src/components/__tests__/StackGrid.spec.js
@@ -129,7 +129,7 @@ describe('<StackGrid /> (GridInline)', () => {
     expect(callback.mock.calls.length).toBe(2);
   });
 
-  test('Should be use horizontal', () => {
+  test('Should be horizontal', () => {
     const testMockProps = Object.assign({}, mockProps, {
       size: {
         width: 320,
@@ -151,5 +151,34 @@ describe('<StackGrid /> (GridInline)', () => {
     expect(wrapper.find('span').at(1).prop('style').transform).toBe('translateX(7.5px) translateY(15px)');
     expect(wrapper.find('span').at(2).prop('style').transform).toBe('translateX(162.5px) translateY(10px)');
     expect(wrapper.find('span').at(3).prop('style').transform).toBe('translateX(162.5px) translateY(15px)');
+  });
+
+  test('Should be horizontal RTL', () => {
+    const testMockProps = Object.assign({}, mockProps, {
+      size: {
+        width: 320,
+        height: 0,
+      },
+      rtl: true,
+      horizontal: true,
+    });
+
+    const wrapper = mount(
+      <GridInline {...testMockProps}>
+        <div className="item" key="1">ITEM 1</div>
+        <div className="item" key="2">ITEM 2</div>
+        <div className="item" key="3">ITEM 3</div>
+        <div className="item" key="4">ITEM 4</div>
+      </GridInline>
+    );
+    expect(wrapper.find('span').at(0).prop('style').right).toBe(0);
+    expect(wrapper.find('span').at(1).prop('style').right).toBe(0);
+    expect(wrapper.find('span').at(2).prop('style').right).toBe(0);
+    expect(wrapper.find('span').at(3).prop('style').right).toBe(0);
+
+    expect(wrapper.find('span').at(0).prop('style').transform).toBe('translateX(-7.5px) translateY(10px)');
+    expect(wrapper.find('span').at(1).prop('style').transform).toBe('translateX(-7.5px) translateY(15px)');
+    expect(wrapper.find('span').at(2).prop('style').transform).toBe('translateX(-162.5px) translateY(10px)');
+    expect(wrapper.find('span').at(3).prop('style').transform).toBe('translateX(-162.5px) translateY(15px)');
   });
 });


### PR DESCRIPTION
Hello,
I have added rtl option to StackGrid:

the purpose is to layout items from right-to-left instead of the
default left-to-right
The implementation is straightforward: instead of having the StackItem
start with left:0 and transformX:${left}px, when rtl is true, we
start with right:0 and transformX${-left}px.
I updated the demo to include a checkbox for switching RTL/LTR. Run
npm start then check/uncheck the RTL checkbox and see how it works.

I added tests for this functionality.

The code passes npm test.

I updated the document at README.md.